### PR TITLE
Map single value returns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-aurora-data-api-client",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/data-api.js
+++ b/src/data-api.js
@@ -97,13 +97,11 @@ function dataAPI(ClientRDSDataAPI, Client, dialect) {
       if (obj.method === 'insert') {
         if (dialect === 'mysql') {
           obj.response = [obj.response.insertId];
-        } else {
           // The data-api client is returning single fields in an object
-          if (obj.returning && !Array.isArray(obj.returning) && obj.returning !== '*') {
-            obj.response = obj.response.records.map((record) => record[obj.returning]);
-          } else {
-            obj.response = obj.response.records;
-          }
+        } else if (obj.returning && !Array.isArray(obj.returning) && obj.returning !== '*') {
+          obj.response = obj.response.records.map((record) => record[obj.returning]);
+        } else {
+          obj.response = obj.response.records;
         }
       }
 

--- a/src/data-api.js
+++ b/src/data-api.js
@@ -98,7 +98,12 @@ function dataAPI(ClientRDSDataAPI, Client, dialect) {
         if (dialect === 'mysql') {
           obj.response = [obj.response.insertId];
         } else {
-          obj.response = obj.response.records;
+          // The data-api client is returning single fields in an object
+          if (obj.returning && !Array.isArray(obj.returning) && obj.returning !== '*') {
+            obj.response = obj.response.records.map((record) => record[obj.returning]);
+          } else {
+            obj.response = obj.response.records;
+          }
         }
       }
 

--- a/test/integration/data-api-postgres.test.js
+++ b/test/integration/data-api-postgres.test.js
@@ -21,7 +21,7 @@ describe('data-api-postgress', () => {
     for (let i = 0; i < tableNames.length; i++) {
       const tableName = tableNames[tableNames.length - i - 1];
       console.log(`Drop table ${tableName}`);
-      await postgres.schema.dropTable(tableName);
+      await postgres.raw(`DROP TABLE "${tableName}" CASCADE`);
     }
   });
 
@@ -118,6 +118,20 @@ describe('data-api-postgress', () => {
 
       expect(rows.length).to.equal(2);
     });
+  });
+
+  it('should insert a row and return an array of ids', async () => {
+    const tableName = 'test-' + counter++;
+
+    await postgres.schema.createTable(tableName, (table) => {
+      table.increments();
+      table.string('value');
+    });
+
+    const rows = await postgres.table(tableName).insert({ value: 'test' }).returning('id');
+
+    expect(rows.length).to.equal(1);
+    expect(rows[0]).to.equal(1);
   });
 
   describe('errors', () => {

--- a/test/integration/local-postgres.test.js
+++ b/test/integration/local-postgres.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 
 const postgres = require('knex')({
   client: 'pg',
-  connection: 'postgres://localhost/test',
+  connection: 'postgres://localhost',
 });
 
 let counter = 0;
@@ -99,6 +99,20 @@ describe('postgres', () => {
 
       expect(rows.length).to.equal(2);
     });
+  });
+
+  it('should insert a row and return an array of ids', async () => {
+    const tableName = 'test-' + counter++;
+
+    await postgres.schema.createTable(tableName, (table) => {
+      table.increments();
+      table.string('value');
+    });
+
+    const rows = await postgres.table(tableName).insert({ value: 'test' }).returning('id');
+
+    expect(rows.length).to.equal(1);
+    expect(rows[0]).to.equal(1);
   });
 
   describe('whereIn', () => {


### PR DESCRIPTION
Fixes #29 

Postgres should return an array of values when specifying a single returning value for an insert.