### PR TITLE
Decrease npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.2.5",
   "description": "Knex Aurora Data API Client",
   "main": "index.js",
+  "files": [
+    "src/**/*.js"
+  ],
   "scripts": {
     "lint": "eslint src",
     "test": "mocha test/**/*.test.js --timeout 10000",


### PR DESCRIPTION
include only source files in npm package(index.js will be included as it's "main")

relates to #6 

using this command to test
```sh
mkdir test-size && cd test-size && 
npm init -y && 
npm i knex-aurora-data-api-client && 
du -hs node_modules/knex-aurora-data-api-client && 
cd .. && rm -rf test-size
```