### PR TITLE
Parse postgres datetime in UTC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-aurora-data-api-client",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Knex Aurora Data API Client",
   "main": "index.js",
   "files": [

--- a/src/data-api.js
+++ b/src/data-api.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable no-param-reassign */
-/* eslint-disable no-plusplus */
-/* eslint-disable no-undef */
 
 const dataApiClient = require('data-api-client');
 const util = require('util');
@@ -129,12 +127,12 @@ function dataAPI(ClientRDSDataAPI, Client, dialect) {
           const { records, columnMetadata } = obj.response;
 
           // Iterate through the data
-          for (let i = 0; i < columnMetadata.length; i++) {
+          for (let i = 0; i < columnMetadata.length; i += 1) {
             const { tableName } = columnMetadata[i];
             const { label } = columnMetadata[i];
 
             // Iterate through responses
-            for (let j = 0; j < records.length; j++) {
+            for (let j = 0; j < records.length; j += 1) {
               if (!res[j]) res[j] = {};
               if (!res[j][tableName]) res[j][tableName] = {};
               res[j][tableName][label] = records[j][label];

--- a/src/types.js
+++ b/src/types.js
@@ -7,7 +7,13 @@ function applyRecord(columnMetadata, record) {
       switch (column.typeName) {
         case 'timestamp':
         case 'timestamptz':
-          parsedColumns[column.name] = new Date(record[column.name]);
+          // Postgres format 2001-01-01 00:00:00
+          const [, year, month, day, hour, minute, second] = record[column.name].match(
+            /^(\d{1,4})-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})$/,
+          );
+          parsedColumns[column.name] = new Date(
+            Date.UTC(year, month - 1, day, hour, minute, second),
+          );
           break;
         case 'json':
         case 'jsonb':

--- a/src/types.js
+++ b/src/types.js
@@ -8,6 +8,7 @@ function applyRecord(columnMetadata, record) {
         case 'timestamp':
         case 'timestamptz':
           // Postgres format 2001-01-01 00:00:00
+          // eslint-disable-next-line no-case-declarations
           const [, year, month, day, hour, minute, second] = record[column.name].match(
             /^(\d{1,4})-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})$/,
           );

--- a/test/integration/common-tests.js
+++ b/test/integration/common-tests.js
@@ -79,7 +79,7 @@ async function queryForATimestampField(knex) {
     table.timestamp('date');
   });
 
-  const date = new Date();
+  const date = new Date('2001-01-01');
 
   await knex.table(tableName).insert({ date });
 
@@ -88,6 +88,7 @@ async function queryForATimestampField(knex) {
   expect(rows.length).to.equal(1);
 
   expect(Object.prototype.toString.call(rows[0].date)).to.equal('[object Date]');
+  expect(rows[0].date.toUTCString()).to.equal(date.toUTCString());
 }
 
 async function queryForASingleJSONField(knex) {


### PR DESCRIPTION
The timezone was applied to the timestamps when parsing dates from the database.