### PR TITLE
Truncate microsecond timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-aurora-data-api-client",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Knex Aurora Data API Client",
   "main": "index.js",
   "files": [

--- a/src/types.js
+++ b/src/types.js
@@ -7,10 +7,10 @@ function applyRecord(columnMetadata, record) {
       switch (column.typeName) {
         case 'timestamp':
         case 'timestamptz':
-          // Postgres format 2001-01-01 00:00:00
+          // Postgres format 2001-01-01 00:00:00 or 2001-01-01 00:00:00.123456
           // eslint-disable-next-line no-case-declarations
           const [, year, month, day, hour, minute, second] = record[column.name].match(
-            /^(\d{1,4})-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})$/,
+            /^(\d{1,4})-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})(?:.(\d{1,3}))?(?:\d{1,3})?$/,
           );
           parsedColumns[column.name] = new Date(
             Date.UTC(year, month - 1, day, hour, minute, second),


### PR DESCRIPTION
Looks like the postgres timestamp have higher resolution.. 