### PR TITLE
Fix padEnd regression

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -6,19 +6,19 @@ function applyRecord(columnMetadata, record) {
     if (record[column.name]) {
       switch (column.typeName) {
         case 'timestamp':
-        case 'timestamptz': {
+        case 'timestamptz':
           // Postgres format 2001-01-01 00:00:00 or 2001-01-01 00:00:00.123456
           // eslint-disable-next-line no-case-declarations
           const [, year, month, day, hour, minute, second, millisecond] = record[column.name].match(
             /^(\d{1,4})-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})(?:.(\d{1,3}))?(?:\d{1,3})?$/,
           );
 
+          // eslint-disable-next-line no-case-declarations
           const millisecondPadded = millisecond === undefined ? '000' : millisecond.padEnd(3, 0);
           parsedColumns[column.name] = new Date(
             Date.UTC(year, month - 1, day, hour, minute, second, millisecondPadded),
           );
           break;
-        }
         case 'json':
         case 'jsonb':
           parsedColumns[column.name] = JSON.parse(record[column.name]);

--- a/src/types.js
+++ b/src/types.js
@@ -6,17 +6,19 @@ function applyRecord(columnMetadata, record) {
     if (record[column.name]) {
       switch (column.typeName) {
         case 'timestamp':
-        case 'timestamptz':
+        case 'timestamptz': {
           // Postgres format 2001-01-01 00:00:00 or 2001-01-01 00:00:00.123456
           // eslint-disable-next-line no-case-declarations
           const [, year, month, day, hour, minute, second, millisecond] = record[column.name].match(
             /^(\d{1,4})-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})(?:.(\d{1,3}))?(?:\d{1,3})?$/,
           );
 
+          const millisecondPadded = millisecond === undefined ? '000' : millisecond.padEnd(3, 0);
           parsedColumns[column.name] = new Date(
-            Date.UTC(year, month - 1, day, hour, minute, second, millisecond.padEnd(3, 0)),
+            Date.UTC(year, month - 1, day, hour, minute, second, millisecondPadded),
           );
           break;
+        }
         case 'json':
         case 'jsonb':
           parsedColumns[column.name] = JSON.parse(record[column.name]);

--- a/test/integration/common-tests.js
+++ b/test/integration/common-tests.js
@@ -139,6 +139,28 @@ async function queryForATruncatedTimestampField(knex) {
   expect(rows[0].date.toISOString()).to.equal(date.toISOString());
 }
 
+async function queryForATimestampFieldWithoutMillis(knex) {
+  const tableName = 'common_test_' + counter++;
+
+  await knex.schema.createTable(tableName, (table) => {
+    table.increments();
+    table.timestamp('date');
+  });
+
+  // It is saved correctly in DB, but SQL command select will retrieve as : 2021-10-07 12:56:16 
+  // This is the same as the above, but the milliseconds are missing entirely
+  const date = new Date('2021-10-07T12:56:16.000Z');
+
+  await knex.table(tableName).insert({ date });
+
+  const rows = await knex.select('date').from(tableName);
+
+  expect(rows.length).to.equal(1);
+
+  expect(Object.prototype.toString.call(rows[0].date)).to.equal('[object Date]');
+  expect(rows[0].date.toISOString()).to.equal(date.toISOString());
+}
+
 async function queryForASingleJSONField(knex) {
   const tableName = 'common_test_' + counter++;
 


### PR DESCRIPTION
Change #82 introduced a regression where the milliseconds are not present (e.g. `2021-10-07 12:56:16.000`). 

In these cases postgres returns `2021-10-07 12:56:16` with no milliseconds at all. After the regex calling `.padEnd` then causes an error `Cannot read property 'padEnd' of undefined`.

In cases where the milliseconds is undefined, the code now opts to insert `000`.
