### PR TITLE
fix: make infinity timestamps explicit

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -1,23 +1,4 @@
-function parseTimestamp(timestamp) {
-  // Postgres format 2001-01-01 00:00:00 or 2001-01-01 00:00:00.123456
-  // Postgres format +292278994-08-16 23:00:00 or -292275055-05-16 23:00:00 for Infinity values
-  // eslint-disable-next-line no-case-declarations
-  const [, year, month, day, hour, minute, second, millisecond = ''] = timestamp.match(
-    /^([+|-]?\d+)-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})(?:.(\d{1,3}))?(?:\d{1,3})?$/,
-  );
-
-  // Data Api may return timestamps out of range of JS max timestamp value of +-8640000000000000
-  // Year comparison is performed first and if the year is in range, then ISO date strings may be compared
-  const yearNumber = Number(year);
-  if (yearNumber > 275760) {
-    return Infinity;
-  }
-  if (yearNumber < -271821) {
-    return -Infinity;
-  }
-
-  return new Date(Date.UTC(year, month - 1, day, hour, minute, second, millisecond.padEnd(3, 0)));
-}
+const { parseTimestamp } = require('./utils');
 
 function applyRecord(columnMetadata, record) {
   const parsedColumns = {};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,33 @@
+/**
+ * Parse Data Api timestamp field to JS native type.
+ * @param {string} timestamp Timestamp string from Data Api
+ * @returns {Date | number}
+ */
+function parseTimestamp(timestamp) {
+  // Postgres format 2001-01-01 00:00:00 or 2001-01-01 00:00:00.123456
+  // Postgres format +292278994-08-16 23:00:00 or -292275055-05-16 23:00:00 for Infinity values
+  // eslint-disable-next-line no-case-declarations
+  const [, year, month, day, hour, minute, second, millisecond = ''] = timestamp.match(
+    /^([+|-]?\d+)-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})(?:.(\d{1,3}))?(?:\d{1,3})?$/,
+  );
+
+  const epochTimestamp = Date.UTC(
+    year,
+    month - 1,
+    day,
+    hour,
+    minute,
+    second,
+    millisecond.padEnd(3, 0),
+  );
+
+  if (epochTimestamp) {
+    return new Date(epochTimestamp);
+  }
+
+  return year[0] === '+' ? Infinity : -Infinity;
+}
+
+module.exports = {
+  parseTimestamp,
+};

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,0 +1,80 @@
+const { expect } = require('chai');
+const utils = require('../../src/utils');
+
+describe('utils', () => {
+  describe('parseTimestamp', () => {
+    it('should parse date in year 2022', () => {
+      const result = utils.parseTimestamp('2022-01-01 00:00:00');
+      expect(result instanceof Date);
+      expect(result.toISOString()).to.equal('2022-01-01T00:00:00.000Z');
+    });
+
+    it('should parse date in year 2022 with 1 millisecond precision', () => {
+      const result = utils.parseTimestamp('2022-01-01 00:00:00.1');
+      expect(result instanceof Date);
+      expect(result.toISOString()).to.equal('2022-01-01T00:00:00.100Z');
+    });
+
+    it('should parse date in year 2022 with 2 millisecond precision', () => {
+      const result = utils.parseTimestamp('2022-01-01 00:00:00.12');
+      expect(result instanceof Date);
+      expect(result.toISOString()).to.equal('2022-01-01T00:00:00.120Z');
+    });
+
+    it('should parse date in year 2022 with 3 millisecond precision', () => {
+      const result = utils.parseTimestamp('2022-01-01 00:00:00.123');
+      expect(result instanceof Date);
+      expect(result.toISOString()).to.equal('2022-01-01T00:00:00.123Z');
+    });
+
+    it('should parse date in year 2022 with 6 millisecond precision', () => {
+      const result = utils.parseTimestamp('2022-01-01 00:00:00.123456');
+      expect(result instanceof Date);
+      expect(result.toISOString()).to.equal('2022-01-01T00:00:00.123Z');
+    });
+
+    it('should parse max js date', () => {
+      const result = utils.parseTimestamp('+275760-09-13 00:00:00');
+      expect(result instanceof Date);
+      expect(result.toISOString()).to.equal('+275760-09-13T00:00:00.000Z');
+    });
+
+    it('should parse max js date with milliseconds', () => {
+      const result = utils.parseTimestamp('+275760-09-13 00:00:00.000000');
+      expect(result instanceof Date);
+      expect(result.toISOString()).to.equal('+275760-09-13T00:00:00.000Z');
+    });
+
+    it('should parse just over max js date to Infinity', () => {
+      const result = utils.parseTimestamp('+275760-09-13 00:00:00.1');
+      expect(result).to.equal(Infinity);
+    });
+
+    it('should parse positive out of range date to Infinity', () => {
+      const result = utils.parseTimestamp('+292278994-08-16 23:00:00');
+      expect(result).to.equal(Infinity);
+    });
+
+    it('should parse min js date', () => {
+      const result = utils.parseTimestamp('-271821-04-20 00:00:00');
+      expect(result instanceof Date);
+      expect(result.toISOString()).to.equal('-271821-04-20T00:00:00.000Z');
+    });
+
+    it('should parse min js date with milliseconds', () => {
+      const result = utils.parseTimestamp('-271821-04-20 00:00:00.000000');
+      expect(result instanceof Date);
+      expect(result.toISOString()).to.equal('-271821-04-20T00:00:00.000Z');
+    });
+
+    it('should parse just under min js date to negative Infinity', () => {
+      const result = utils.parseTimestamp('-271821-04-19 23:59:59.999');
+      expect(result).to.equal(-Infinity);
+    });
+
+    it('should parse negative out of range date to negative Infinity', () => {
+      const result = utils.parseTimestamp('-292275055-05-16 23:00:00');
+      expect(result).to.equal(-Infinity);
+    });
+  });
+});


### PR DESCRIPTION
As [noted](https://github.com/markusahlstrand/knex-data-api-client/pull/88#discussion_r810508847), the previous work would still yield wrong results near the min / max JS date.

In this PR I simplified handling of Infinity values. If `Date.UTC` number is out of range, it returns `NaN` and we know that Infinity value should be returned. The sign may be determined from the year.

Unit tests are included.

As a side note, I noticed that the milliseconds are truncated instead of rounded. Is this expected behavior? E.g. timestamp of  `'+275760-09-13 00:00:00.000500'` should technically be parsed to Infinity, but because the milliseconds are truncated, it is parsed to `'+275760-09-13T00:00:00.000Z'`. This is not specific to Infinity values, but all timestamps. I don't prefer one over to another, because I don't have to think about so precise timestamps currently. :)